### PR TITLE
Simplify curl dual stack IPv4 / IPv6 handling

### DIFF
--- a/src/core/curl_get.cc
+++ b/src/core/curl_get.cc
@@ -92,11 +92,7 @@ CurlGet::start() {
   curl_easy_setopt(m_handle, CURLOPT_FOLLOWLOCATION, (long)1);
   curl_easy_setopt(m_handle, CURLOPT_MAXREDIRS,      (long)5);
 
-  curl_easy_setopt(m_handle, CURLOPT_IPRESOLVE,      CURL_IPRESOLVE_WHATEVER);
-
   curl_easy_setopt(m_handle, CURLOPT_ENCODING,       "");
-
-  m_ipv6 = false;
 
   m_stack->add_get(this);
 }
@@ -112,17 +108,6 @@ CurlGet::close() {
   curl_easy_cleanup(m_handle);
 
   m_handle = NULL;
-}
-
-void
-CurlGet::retry_ipv6() {
-  CURL* nhandle = curl_easy_duphandle(m_handle);
-
-  curl_easy_setopt(nhandle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
-  curl_easy_cleanup(m_handle);
-
-  m_handle = nhandle;
-  m_ipv6 = true;
 }
 
 void

--- a/src/core/curl_get.h
+++ b/src/core/curl_get.h
@@ -58,9 +58,6 @@ public:
   void               start();
   void               close();
 
-  bool               is_using_ipv6()    { return m_ipv6; }
-  void               retry_ipv6();
-
   bool               is_busy() const    { return m_handle; }
   bool               is_active() const  { return m_active; }
 
@@ -78,7 +75,6 @@ private:
   void               receive_timeout();
 
   bool               m_active;
-  bool               m_ipv6;
 
   rak::priority_item m_taskTimeout;
   

--- a/src/core/curl_stack.cc
+++ b/src/core/curl_stack.cc
@@ -134,16 +134,9 @@ CurlStack::process_done_handle() {
 
   if (msg->data.result == CURLE_COULDNT_RESOLVE_HOST) {
     iterator itr = std::find_if(begin(), end(), rak::equal(msg->easy_handle, std::mem_fun(&CurlGet::handle)));
- 
+
     if (itr == end())
       throw torrent::internal_error("Could not find CurlGet when calling CurlStack::receive_action.");
- 
-    if (!(*itr)->is_using_ipv6()) {
-      (*itr)->retry_ipv6();
-
-      if (curl_multi_add_handle((CURLM*)m_handle, (*itr)->handle()) > 0)
-        throw torrent::internal_error("Error calling curl_multi_add_handle.");
-    }
 
   } else {
     transfer_done(msg->easy_handle,


### PR DESCRIPTION
curl implements the RFC 6555 "Happy Eyeballs" algorithm, meaning a
manual fallback to IPv6 is uncessary and arguably detrimental.

If we leave curl to it's own devices with the request, it will attempt
to connect on both IPv4 and IPv6, then use whichever connection is
going to be more reliable.