### PR TITLE
Add fallocate all feature to improve read performance

### DIFF
--- a/.rtorrent.rc
+++ b/.rtorrent.rc
@@ -28,3 +28,20 @@ network.max_open_sockets.set = 2048
 # These settings allow up 2.5G per socket with a 250ms bandwidth delay product
 network.send_buffer.size.set = 32M
 network.receive_buffer.size.set = 32M
+
+# Preallocate disk space for contents of a torrent
+#
+# Useful for reducing fragmentation, improving the performance
+# and I/O patterns of future read operations. However, with this
+# enabled, preallocated files will occupy the full size even if
+# they are not completed.
+#
+# If you choose to allocate space for the whole torrent at once,
+# rTorrent will create all files and allocate the space when the
+# torrent is started. rTorrent will NOT delete the file and free
+# the allocated space, if you later mark a file as DO NOT DOWNLOAD.
+#
+#   0 = disabled
+#   1 = enabled, allocate when a file is opened for write
+#   2 = enabled, allocate the space for the whole torrent at once
+system.file.allocate.set = 0

--- a/libtorrent/src/torrent/data/file.h
+++ b/libtorrent/src/torrent/data/file.h
@@ -52,10 +52,11 @@ public:
   static const int flag_create_queued      = (1 << 1);
   static const int flag_resize_queued      = (1 << 2);
   static const int flag_fallocate          = (1 << 3);
-  static const int flag_previously_created = (1 << 4);
+  static const int flag_fallocate_all      = (1 << 4);
+  static const int flag_previously_created = (1 << 5);
 
-  static const int flag_prioritize_first   = (1 << 5);
-  static const int flag_prioritize_last    = (1 << 6);
+  static const int flag_prioritize_first   = (1 << 6);
+  static const int flag_prioritize_last    = (1 << 7);
 
   File();
   ~File();
@@ -166,12 +167,12 @@ File::is_valid_position(uint64_t p) const {
 
 inline void
 File::set_flags(int flags) {
-  set_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last));
+  set_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_fallocate_all | flag_prioritize_first | flag_prioritize_last));
 }
 
 inline void
 File::unset_flags(int flags) {
-  unset_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_prioritize_first | flag_prioritize_last));
+  unset_flags_protected(flags & (flag_create_queued | flag_resize_queued | flag_fallocate | flag_fallocate_all | flag_prioritize_first | flag_prioritize_last));
 }
 
 inline void

--- a/libtorrent/src/torrent/download.cc
+++ b/libtorrent/src/torrent/download.cc
@@ -110,6 +110,9 @@ Download::open(int flags) {
   if (flags & open_enable_fallocate)
     fileFlags |= File::flag_fallocate;
 
+  if (flags & open_enable_fallocate_all)
+    fileFlags |= File::flag_fallocate_all;
+
   for (FileList::iterator itr = m_ptr->main()->file_list()->begin(), last = m_ptr->main()->file_list()->end(); itr != last; itr++)
     (*itr)->set_flags(fileFlags);
 }

--- a/libtorrent/src/torrent/download.h
+++ b/libtorrent/src/torrent/download.h
@@ -61,13 +61,13 @@ public:
 
   // Start and open flags can be stored in the same integer, same for
   // stop and close flags.
-  static const int open_enable_fallocate = (1 << 0);
+  static const int open_enable_fallocate     = (1 << 0);
+  static const int open_enable_fallocate_all = (1 << 1);
 
-  static const int start_no_create       = (1 << 1);
-  static const int start_keep_baseline   = (1 << 2);
-  static const int start_skip_tracker    = (1 << 3);
-
-  static const int stop_skip_tracker     = (1 << 0);
+  static const int start_no_create       = (1 << 2);
+  static const int start_keep_baseline   = (1 << 3);
+  static const int start_skip_tracker    = (1 << 4);
+  static const int stop_skip_tracker     = (1 << 5);
 
   Download(DownloadWrapper* d = NULL) : m_ptr(d) {}
 

--- a/rtorrent/src/core/download_list.cc
+++ b/rtorrent/src/core/download_list.cc
@@ -254,8 +254,13 @@ DownloadList::open_throw(Download* download) {
   
   int openFlags = download->resume_flags();
 
-  if (rpc::call_command_value("system.file.allocate"))
+  auto fileAllocate = rpc::call_command_value("system.file.allocate");
+
+  if (fileAllocate)
     openFlags |= torrent::Download::open_enable_fallocate;
+
+  if (fileAllocate == 2)
+    openFlags |= torrent::Download::open_enable_fallocate_all;
 
   download->download()->open(openFlags);
   DL_TRIGGER_EVENT(download, "event.download.opened");


### PR DESCRIPTION
This pull request allows the disk space for the entire torrent to be allocated at once to improve read performance.