### PR TITLE
libtorrent: Optimize chunk selection based on priority

### DIFF
--- a/libtorrent/src/download/chunk_selector.cc
+++ b/libtorrent/src/download/chunk_selector.cc
@@ -88,7 +88,7 @@ ChunkSelector::update_priorities() {
 }
 
 uint32_t
-ChunkSelector::find(PeerChunks* pc, __UNUSED bool highPriority) {
+ChunkSelector::find(PeerChunks* pc, bool highPriority) {
   // This needs to be re-enabled.
   if (m_position == invalid_chunk)
     return invalid_chunk;
@@ -128,24 +128,15 @@ ChunkSelector::find(PeerChunks* pc, __UNUSED bool highPriority) {
 
   queue->clear();
 
-  (search_linear(pc->bitfield(), queue, m_data->high_priority(), m_position, size()) &&
-   search_linear(pc->bitfield(), queue, m_data->high_priority(), 0, m_position));
-
-  if (queue->prepare_pop()) {
-    // Set that the peer has high priority pieces cached.
-
-  } else {
-    // Set that the peer has normal priority pieces cached.
-
-    // Urgh...
-    queue->clear();
-
+  if (highPriority)
+    (search_linear(pc->bitfield(), queue, m_data->high_priority(), m_position, size()) &&
+     search_linear(pc->bitfield(), queue, m_data->high_priority(), 0, m_position));
+  else
     (search_linear(pc->bitfield(), queue, m_data->normal_priority(), m_position, size()) &&
      search_linear(pc->bitfield(), queue, m_data->normal_priority(), 0, m_position));
-
-    if (!queue->prepare_pop())
-      return invalid_chunk;
-  }
+	 
+  if (!queue->prepare_pop())
+    return invalid_chunk;
 
   uint32_t pos = queue->pop();
   

--- a/libtorrent/src/download/delegator.cc
+++ b/libtorrent/src/download/delegator.cc
@@ -78,12 +78,15 @@ Delegator::delegate(PeerChunks* peerChunks, uint32_t affinity, uint32_t maxPiece
         delegate_from_blocklist(new_transfers, maxPieces, itr, peerInfo);
     }
     // Create new high priority pieces.
-    delegate_new_chunks(new_transfers, maxPieces, peerChunks, true);
+    delegate_new_chunks(new_transfers, maxPieces, peerChunks, true);	
+    if (new_transfers.size() >= maxPieces)
+      return new_transfers;
+	
     // Create new normal priority pieces.
     delegate_new_chunks(new_transfers, maxPieces, peerChunks, false);
+    if (new_transfers.size() >= maxPieces)
+      return new_transfers;
   }
-  if (new_transfers.size() >= maxPieces)
-    return new_transfers;
 
   // Find existing high priority pieces.
   for (BlockList* itr : m_transfers) {


### PR DESCRIPTION
This pull request optimizes the chunk selector search algorithm. It allows only searching the bitfield for the piece priority type we're looking for. Support is added to the download delegator to support this optimized search algorithm. The download delegator is also optimized to avoid searching the bitfield for normal priority pieces, when high priority pieces are found.

The result is a reduction in CPU usage when downloading torrents and an increase in the maximum download speed ceiling. Furthermore, high priority files are also downloaded quicker, with less normal priority pieces in the download queue.