### PR TITLE
libtorrent: Increase max throttle speed to UINT_MAX

### DIFF
--- a/libtorrent/src/torrent/throttle.h
+++ b/libtorrent/src/torrent/throttle.h
@@ -54,8 +54,8 @@ public:
   bool                is_throttled();
 
   // 0 == UNLIMITED.
-  uint32_t            max_rate() const { return m_maxRate; }
-  void                set_max_rate(uint32_t v);
+  uint64_t            max_rate() const { return m_maxRate; }
+  void                set_max_rate(uint64_t v);
 
   const Rate*         rate() const;
 
@@ -64,6 +64,8 @@ public:
 protected:
   Throttle() {}
   ~Throttle() {}
+  
+  const uint32_t THROTTLE_MIN_VALUE = 2097152;
 
   ThrottleInternal*       m_ptr()       { return reinterpret_cast<ThrottleInternal*>(this); }
   const ThrottleInternal* c_ptr() const { return reinterpret_cast<const ThrottleInternal*>(this); }
@@ -72,7 +74,7 @@ protected:
   uint32_t            calculate_max_chunk_size() const LIBTORRENT_NO_EXPORT;
   uint32_t            calculate_interval() const LIBTORRENT_NO_EXPORT;
 
-  uint32_t            m_maxRate;
+  uint64_t            m_maxRate;
 
   ThrottleList*       m_throttleList;
 };


### PR DESCRIPTION
This commit increases the maximum throttle speed to just over 500MB/s. It also sets a minimum throttle speed of approximately 256kb/s to modernize the throttle code.