### PR TITLE
libtorrent: Optimize unsigned int datatypes

### DIFF
--- a/libtorrent/src/net/throttle_internal.h
+++ b/libtorrent/src/net/throttle_internal.h
@@ -62,7 +62,7 @@ public:
 
 private:
   // Fraction is a fixed-precision value with the given number of bits after the decimal point.
-  static const uint32_t fraction_bits = 16;
+  static const uint8_t  fraction_bits = 16;
   static const uint32_t fraction_base = (1 << fraction_bits);
 
   typedef std::vector<ThrottleInternal*>  SlaveList;

--- a/libtorrent/src/protocol/handshake.h
+++ b/libtorrent/src/protocol/handshake.h
@@ -54,19 +54,19 @@ class DownloadMain;
 
 class Handshake : public SocketStream {
 public:
-  static const uint32_t part1_size     = 20 + 28;
-  static const uint32_t part2_size     = 20;
-  static const uint32_t handshake_size = part1_size + part2_size;
+  static const uint8_t part1_size     = 20 + 28;
+  static const uint8_t part2_size     = 20;
+  static const uint8_t handshake_size = part1_size + part2_size;
 
-  static const uint32_t protocol_bitfield  = 5;
-  static const uint32_t protocol_port      = 9;
-  static const uint32_t protocol_extension = 20;
+  static const uint8_t protocol_bitfield  = 5;
+  static const uint8_t protocol_port      = 9;
+  static const uint8_t protocol_extension = 20;
 
-  static const uint32_t enc_negotiation_size = 8 + 4 + 2;
-  static const uint32_t enc_pad_size         = 512;
-  static const uint32_t enc_pad_read_size    = 96 + enc_pad_size + 20;
+  static const uint8_t enc_negotiation_size = 8 + 4 + 2;
+  static const uint16_t enc_pad_size         = 512;
+  static const uint16_t enc_pad_read_size    = 96 + enc_pad_size + 20;
 
-  static const uint32_t buffer_size = enc_pad_read_size + 20 + enc_negotiation_size + enc_pad_size + 2 + handshake_size + 5;
+  static const uint16_t buffer_size = enc_pad_read_size + 20 + enc_negotiation_size + enc_pad_size + 2 + handshake_size + 5;
 
   typedef ProtocolBuffer<buffer_size> Buffer;
 

--- a/libtorrent/src/protocol/peer_connection_base.h
+++ b/libtorrent/src/protocol/peer_connection_base.h
@@ -78,7 +78,7 @@ public:
 #endif
 
   // Find an optimal number for this.
-  static const uint32_t read_size = 64;
+  static const uint8_t read_size = 64;
 
   // Bitmasks for peer exchange messages to send.
   static const int PEX_DO      = (1 << 0);

--- a/libtorrent/src/protocol/protocol_base.h
+++ b/libtorrent/src/protocol/protocol_base.h
@@ -49,6 +49,7 @@ class ProtocolBase {
 public:
   typedef ProtocolBuffer<512> Buffer;
   typedef uint32_t            size_type;
+  typedef uint8_t             sizeof_type;
 
   static const size_type buffer_size = 512;
 
@@ -116,22 +117,22 @@ public:
   void                write_port(uint16_t port);
   void                write_extension(uint8_t id, uint32_t length);
 
-  static const size_type sizeof_keepalive    = 4;
-  static const size_type sizeof_choke        = 5;
-  static const size_type sizeof_interested   = 5;
-  static const size_type sizeof_have         = 9;
-  static const size_type sizeof_have_body    = 4;
-  static const size_type sizeof_bitfield     = 5;
-  static const size_type sizeof_request      = 17;
-  static const size_type sizeof_request_body = 12;
-  static const size_type sizeof_cancel       = 17;
-  static const size_type sizeof_cancel_body  = 12;
-  static const size_type sizeof_piece        = 13;
-  static const size_type sizeof_piece_body   = 8;
-  static const size_type sizeof_port         = 7;
-  static const size_type sizeof_port_body    = 2;
-  static const size_type sizeof_extension    = 6;
-  static const size_type sizeof_extension_body=1;
+  static const sizeof_type sizeof_keepalive    = 4;
+  static const sizeof_type sizeof_choke        = 5;
+  static const sizeof_type sizeof_interested   = 5;
+  static const sizeof_type sizeof_have         = 9;
+  static const sizeof_type sizeof_have_body    = 4;
+  static const sizeof_type sizeof_bitfield     = 5;
+  static const sizeof_type sizeof_request      = 17;
+  static const sizeof_type sizeof_request_body = 12;
+  static const sizeof_type sizeof_cancel       = 17;
+  static const sizeof_type sizeof_cancel_body  = 12;
+  static const sizeof_type sizeof_piece        = 13;
+  static const sizeof_type sizeof_piece_body   = 8;
+  static const sizeof_type sizeof_port         = 7;
+  static const sizeof_type sizeof_port_body    = 2;
+  static const sizeof_type sizeof_extension    = 6;
+  static const sizeof_type sizeof_extension_body = 1;
 
   bool                can_write_keepalive() const             { return m_buffer.reserved_left() >= sizeof_keepalive; }
   bool                can_write_choke() const                 { return m_buffer.reserved_left() >= sizeof_choke; }

--- a/libtorrent/src/torrent/connection_manager.h
+++ b/libtorrent/src/torrent/connection_manager.h
@@ -84,6 +84,7 @@ public:
   typedef uint32_t size_type;
   typedef uint16_t port_type;
   typedef uint8_t  priority_type;
+  typedef uint8_t  encryption_type;
 
   static const priority_type iptos_default     = 0;
   static const priority_type iptos_lowdelay    = IPTOS_LOWDELAY;
@@ -98,17 +99,17 @@ public:
   static const priority_type iptos_mincost     = iptos_throughput;
 #endif
 
-  static const uint32_t encryption_none             = 0;
-  static const uint32_t encryption_allow_incoming   = (1 << 0);
-  static const uint32_t encryption_try_outgoing     = (1 << 1);
-  static const uint32_t encryption_require          = (1 << 2);
-  static const uint32_t encryption_require_RC4      = (1 << 3);
-  static const uint32_t encryption_enable_retry     = (1 << 4);
-  static const uint32_t encryption_prefer_plaintext = (1 << 5);
+  static const encryption_type encryption_none             = 0;
+  static const encryption_type encryption_allow_incoming   = (1 << 0);
+  static const encryption_type encryption_try_outgoing     = (1 << 1);
+  static const encryption_type encryption_require          = (1 << 2);
+  static const encryption_type encryption_require_RC4      = (1 << 3);
+  static const encryption_type encryption_enable_retry     = (1 << 4);
+  static const encryption_type encryption_prefer_plaintext = (1 << 5);
 
   // Internal to libtorrent.
-  static const uint32_t encryption_use_proxy        = (1 << 6);
-  static const uint32_t encryption_retrying         = (1 << 7);
+  static const encryption_type encryption_use_proxy        = (1 << 6);
+  static const encryption_type encryption_retrying         = (1 << 7);
 
   enum {
     handshake_incoming           = 1,

--- a/libtorrent/src/torrent/peer/client_info.h
+++ b/libtorrent/src/torrent/peer/client_info.h
@@ -57,8 +57,8 @@ public:
     const char*         m_shortDescription;
   };    
 
-  static const uint32_t max_key_size = 2;
-  static const uint32_t max_version_size = 4;
+  static const uint8_t max_key_size = 2;
+  static const uint8_t max_version_size = 4;
 
   id_type             type() const                            { return m_type; }
 

--- a/libtorrent/src/torrent/poll.h
+++ b/libtorrent/src/torrent/poll.h
@@ -49,14 +49,14 @@ class LIBTORRENT_EXPORT Poll {
 public:
   typedef std::function<Poll* ()> slot_poll;
 
-  static const int      poll_worker_thread     = 0x1;
-  static const uint32_t flag_waive_global_lock = 0x1;
+  static const int          poll_worker_thread     = 0x1;
+  static const uint8_t      flag_waive_global_lock = 0x1;
 
   Poll() : m_flags(0) {}
   virtual ~Poll() {}
 
-  uint32_t            flags() const { return m_flags; }
-  void                set_flags(uint32_t flags) { m_flags = flags; }
+  uint8_t             flags() const { return m_flags; }
+  void                set_flags(uint8_t flags) { m_flags = flags; }
 
   virtual unsigned int do_poll(int64_t timeout_usec, int flags = 0) = 0;
 
@@ -97,7 +97,7 @@ public:
 private:
   static slot_poll    m_slot_create_poll;
 
-  uint32_t            m_flags;
+  uint8_t             m_flags;
 };
 
 }


### PR DESCRIPTION
Every byte counts if we want to hit the CPU cache.