### PR TITLE
libtorrent: Implement two hash queue threads

### DIFF
--- a/libtorrent/src/manager.cc
+++ b/libtorrent/src/manager.cc
@@ -87,6 +87,13 @@ Manager::Manager() :
               m_main_thread_main.signal_bitfield()->add_signal(std::bind(&HashQueue::work, m_hashQueue)),
               std::placeholders::_1);
 
+  m_hashQueueTwo = new HashQueue(&m_sub_thread_disk);
+  m_hashQueueTwo->slot_has_work() =
+    std::bind(&thread_base::send_event_signal,
+              &m_main_thread_main,
+              m_main_thread_main.signal_bitfield()->add_signal(std::bind(&HashQueue::work, m_hashQueueTwo)),
+              std::placeholders::_1);
+
   m_taskTick.slot() = std::bind(&Manager::receive_tick, this);
 
   priority_queue_insert(&taskScheduler, &m_taskTick, cachedTime.round_seconds());

--- a/libtorrent/src/manager.h
+++ b/libtorrent/src/manager.h
@@ -72,7 +72,7 @@ public:
   DownloadManager*    download_manager()                        { return m_downloadManager; }
   FileManager*        file_manager()                            { return m_fileManager; }
   HandshakeManager*   handshake_manager()                       { return m_handshakeManager; }
-  HashQueue*          hash_queue()                              { return m_hashQueue; }
+  HashQueue*          hash_queue()                              { return ++m_hashQueueCount % 2 == 0 ? m_hashQueue : m_hashQueueTwo; }
   ResourceManager*    resource_manager()                        { return m_resourceManager; }
 
   ChunkManager*       chunk_manager()                           { return m_chunkManager; }
@@ -84,6 +84,7 @@ public:
 
   thread_main*        main_thread_main()                        { return &m_main_thread_main; }
   thread_disk*        main_thread_disk()                        { return &m_main_thread_disk; }
+  thread_disk*        sub_thread_disk()                         { return &m_sub_thread_disk; }
 
   EncodingList*       encoding_list()                           { return &m_encodingList; }
 
@@ -100,6 +101,7 @@ private:
   FileManager*        m_fileManager;
   HandshakeManager*   m_handshakeManager;
   HashQueue*          m_hashQueue;
+  HashQueue*          m_hashQueueTwo;
   ResourceManager*    m_resourceManager;
 
   ChunkManager*       m_chunkManager;
@@ -109,12 +111,15 @@ private:
 
   thread_main         m_main_thread_main;
   thread_disk         m_main_thread_disk;
+  thread_disk         m_sub_thread_disk;
 
   EncodingList        m_encodingList;
 
   Throttle*           m_uploadThrottle;
   Throttle*           m_downloadThrottle;
 
+  uint64_t            m_hashQueueCount;
+	
   unsigned int        m_ticks;
   rak::priority_item  m_taskTick;
 };

--- a/libtorrent/src/torrent/torrent.cc
+++ b/libtorrent/src/torrent/torrent.cc
@@ -110,6 +110,8 @@ initialize() {
 
   manager->main_thread_disk()->init_thread();
   manager->main_thread_disk()->start_thread();
+  manager->sub_thread_disk()->init_thread();
+  manager->sub_thread_disk()->start_thread();
 }
 
 // Clean up and close stuff. Stopping all torrents and waiting for
@@ -120,6 +122,7 @@ cleanup() {
     throw internal_error("torrent::cleanup() called but the library is not initialized.");
 
   manager->main_thread_disk()->stop_thread_wait();
+  manager->sub_thread_disk()->stop_thread_wait();
 
   delete manager;
   manager = NULL;


### PR DESCRIPTION
We can evenly divide the downloads between two different HashQueue objects. This allows us to create anther disk thread to schedule the CPU load more evenly between multiple processor cores. A common scenario is for 30% of the CPU usage to be allocated for hashing. This pull request would split that load between two threads at 15% when multiple downloads are active.