### PR TITLE
libtorrent: Fix instrumentation debug regression

### DIFF
--- a/libtorrent/src/protocol/request_list.cc
+++ b/libtorrent/src/protocol/request_list.cc
@@ -52,9 +52,9 @@
 
 namespace torrent {
 
-#ifdef LT_INSTRUMENTATION
 const int request_list_constants::bucket_count;
 
+#ifdef LT_INSTRUMENTATION
 const instrumentation_enum request_list_constants::instrumentation_added[bucket_count] = {
   INSTRUMENTATION_TRANSFER_REQUESTS_QUEUED_ADDED,
   INSTRUMENTATION_TRANSFER_REQUESTS_UNORDERED_ADDED,


### PR DESCRIPTION
This commit fixes a regression for debugging the software with instrumentation disabled.