### PR TITLE
libtorrent: Disable UDNS by default

### DIFF
--- a/libtorrent/scripts/udns.m4
+++ b/libtorrent/scripts/udns.m4
@@ -1,26 +1,18 @@
 # dnl function for enabling/disabling udns support
 AC_DEFUN([TORRENT_WITH_UDNS], [
-  AC_ARG_WITH(
-    [udns],
-    AS_HELP_STRING([--without-udns], [Don't use udns, falling back to synchronous DNS resolution.])
-  )
-  # dnl neither ubuntu nor fedora ships a pkgconfig file for udns
-  AS_IF(
-    [test "x$with_udns"  != "xno"],
-    [AC_CHECK_HEADERS([udns.h], [have_udns=yes], [have_udns=no])],
-    [have_udns=no]
-  )
-  AS_IF(
-    [test "x$have_udns" = "xyes"],
+  AC_ARG_ENABLE(udns,
+    AC_HELP_STRING([--enable-udns], [use udns instead of synchronous DNS resolution [[default=check]]]),
     [
-      AC_DEFINE(USE_UDNS, 1, Define to build with udns support.)
-      LIBS="$LIBS -ludns"
-    ],
-    [
-      AS_IF(
-        [test "x$with_udns" = "xyes"],
-        [AC_MSG_ERROR([udns requested but not found])]
-      )
-    ]
-  )
+      if test "$enableval" = "yes"; then
+        AC_CHECK_HEADERS([udns.h], [have_udns=yes], [have_udns=no])
+
+        if test "$have_udns" = "yes"; then
+          AC_DEFINE(USE_UDNS, 1, Define to build with udns support.)
+          LIBS="$LIBS -ludns"
+
+        else
+          AC_MSG_ERROR([udns requested but not found])
+        fi
+      fi
+    ])
 ])

--- a/libtorrent/src/utils/udnsevent.cc
+++ b/libtorrent/src/utils/udnsevent.cc
@@ -57,7 +57,7 @@ void a4_callback_wrapper(struct ::dns_ctx *ctx, ::dns_rr_a4 *result, void *data)
     if (query->a6_query != NULL) {
       ::dns_cancel(ctx, query->a6_query);
     }
-    if (*query->callback) { (*query->callback)(reinterpret_cast<sockaddr_in*>(&sa), 0); }
+    if (*query->callback) { (*query->callback)(reinterpret_cast<sockaddr*>(&sa), 0); }
     delete query;
   }
 }


### PR DESCRIPTION
This feature is currently not stable. Add `--enable-udns` option to libtorrent configure to allow further development testing.