### PR TITLE
libtorrent: Move UDNS resolver callback to valid place

### DIFF
--- a/libtorrent/src/torrent/connection_manager.cc
+++ b/libtorrent/src/torrent/connection_manager.cc
@@ -50,6 +50,7 @@
 
 #ifdef USE_UDNS
 #include "utils/udnsevent.h"
+#include "tracker/tracker_udp.h"
 #endif
 
 namespace torrent {
@@ -76,6 +77,14 @@ public:
 protected:
   UdnsEvent           m_udnsevent;
 };
+
+void
+ConnectionManager::start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err) {
+  if (tracker != NULL) {
+    tracker->start_announce(sa, err);
+  }
+}
+
 #define ASYNC_RESOLVER_IMPL UdnsAsyncResolver
 #else
 class StubAsyncResolver : public AsyncResolver {

--- a/libtorrent/src/torrent/connection_manager.h
+++ b/libtorrent/src/torrent/connection_manager.h
@@ -51,6 +51,10 @@
 
 namespace torrent {
 
+#ifdef USE_UDNS
+class TrackerUdp;
+#endif
+
 // Standard pair of up/down throttles.
 // First element is upload throttle, second element is download throttle.
 typedef std::pair<Throttle*, Throttle*> ThrottlePair;
@@ -181,6 +185,10 @@ public:
   void*               enqueue_async_resolve(const char *name, int family, resolver_callback *cbck);
   void                flush_async_resolves();
   void                cancel_async_resolve(void *query);
+
+#ifdef USE_UDNS
+  void                start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err);
+#endif
 
   // Legacy synchronous resolver interface.
   slot_resolver_type& resolver()          { return m_slot_resolver; }

--- a/libtorrent/src/tracker/tracker_udp.cc
+++ b/libtorrent/src/tracker/tracker_udp.cc
@@ -76,7 +76,12 @@ TrackerUdp::TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int fla
 
   m_taskTimeout.slot() = std::bind(&TrackerUdp::receive_timeout, this);
 
+#ifdef USE_UDNS
+  m_resolver_callback = std::bind(&ConnectionManager::start_udp_announce, manager->connection_manager(), this, std::placeholders::_1, std::placeholders::_2);
+#else
   m_resolver_callback = std::bind(&TrackerUdp::start_announce, this, std::placeholders::_1, std::placeholders::_2);
+#endif
+
   m_resolver_query = NULL;
 }
 

--- a/libtorrent/src/tracker/tracker_udp.h
+++ b/libtorrent/src/tracker/tracker_udp.h
@@ -75,14 +75,14 @@ public:
   virtual void        event_read();
   virtual void        event_write();
   virtual void        event_error();
+  
+  void                start_announce(const sockaddr* sa, int err);
 
 private:
   void                close_directly();
 
   void                receive_failed(const std::string& msg);
   void                receive_timeout();
-
-  void                start_announce(const sockaddr* sa, int err);
 
   void                prepare_connect_input();
   void                prepare_announce_input();


### PR DESCRIPTION
This commit moves the UDNS resolver callback to the connection manager so it's always valid for the life of the query. It fixes a crash with UDNS.