### PR TITLE
libtorrent: Add m_tracker_udp_list

### DIFF
--- a/libtorrent/src/torrent/connection_manager.cc
+++ b/libtorrent/src/torrent/connection_manager.cc
@@ -79,9 +79,9 @@ protected:
 };
 
 void
-ConnectionManager::start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err) {
-  if (tracker != NULL) {
-    tracker->start_announce(sa, err);
+ConnectionManager::start_udp_announce(uint64_t idx, const sockaddr* sa, int err) {
+  if (m_tracker_udp_list[idx] != NULL) {
+    m_tracker_udp_list[idx]->start_announce(sa, err);
   }
 }
 

--- a/libtorrent/src/torrent/connection_manager.cc
+++ b/libtorrent/src/torrent/connection_manager.cc
@@ -50,6 +50,7 @@
 
 #ifdef USE_UDNS
 #include "utils/udnsevent.h"
+#include "tracker/tracker_udp.h"
 #endif
 
 namespace torrent {
@@ -76,6 +77,14 @@ public:
 protected:
   UdnsEvent           m_udnsevent;
 };
+
+void
+ConnectionManager::start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err) {
+  if (tracker != NULL) {
+    tracker->start_announce(sa, err);
+  }
+}
+
 #define ASYNC_RESOLVER_IMPL UdnsAsyncResolver
 #else
 class StubAsyncResolver : public AsyncResolver {

--- a/libtorrent/src/torrent/connection_manager.h
+++ b/libtorrent/src/torrent/connection_manager.h
@@ -51,6 +51,10 @@
 
 namespace torrent {
 
+#ifdef USE_UDNS
+class TrackerUdp;
+#endif
+
 // Standard pair of up/down throttles.
 // First element is upload throttle, second element is download throttle.
 typedef std::pair<Throttle*, Throttle*> ThrottlePair;
@@ -181,6 +185,10 @@ public:
   void*               enqueue_async_resolve(const char *name, int family, resolver_callback *cbck);
   void                flush_async_resolves();
   void                cancel_async_resolve(void *query);
+
+#ifdef USE_UDNS
+  void                start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err);
+#endif
 
   // Legacy synchronous resolver interface.
   slot_resolver_type& resolver()          { return m_slot_resolver; }

--- a/libtorrent/src/torrent/connection_manager.h
+++ b/libtorrent/src/torrent/connection_manager.h
@@ -187,7 +187,10 @@ public:
   void                cancel_async_resolve(void *query);
 
 #ifdef USE_UDNS
-  void                start_udp_announce(TrackerUdp *tracker, const sockaddr* sa, int err);
+  void                start_udp_announce(uint64_t idx, const sockaddr* sa, int err);
+  void                null_udp_tracker(uint64_t idx)          { m_tracker_udp_list[idx] = NULL; }
+  void                add_udp_tracker(TrackerUdp* tracker)    { m_tracker_udp_list.push_back(tracker); }
+  uint64_t            get_udp_tracker_count()                 { return m_tracker_udp_list.size(); }
 #endif
 
   // Legacy synchronous resolver interface.
@@ -226,6 +229,10 @@ private:
   slot_filter_type    m_slot_filter;
   slot_resolver_type  m_slot_resolver;
   slot_throttle_type  m_slot_address_throttle;
+
+#ifdef USE_UDNS
+  std::vector<TrackerUdp*> m_tracker_udp_list;
+#endif
 
   std::unique_ptr<AsyncResolver> m_async_resolver;
 };

--- a/libtorrent/src/tracker/tracker_udp.cc
+++ b/libtorrent/src/tracker/tracker_udp.cc
@@ -76,7 +76,12 @@ TrackerUdp::TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int fla
 
   m_taskTimeout.slot() = std::bind(&TrackerUdp::receive_timeout, this);
 
+#ifdef USE_UDNS
+  m_resolver_callback = std::bind(&ConnectionManager::start_udp_announce, manager->connection_manager(), this, std::placeholders::_1, std::placeholders::_2);
+#else
   m_resolver_callback = std::bind(&TrackerUdp::start_announce, this, std::placeholders::_1, std::placeholders::_2);
+#endif
+
   m_resolver_query = NULL;
 }
 

--- a/libtorrent/src/tracker/tracker_udp.cc
+++ b/libtorrent/src/tracker/tracker_udp.cc
@@ -77,7 +77,9 @@ TrackerUdp::TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int fla
   m_taskTimeout.slot() = std::bind(&TrackerUdp::receive_timeout, this);
 
 #ifdef USE_UDNS
-  m_resolver_callback = std::bind(&ConnectionManager::start_udp_announce, manager->connection_manager(), this, std::placeholders::_1, std::placeholders::_2);
+  manager->connection_manager()->add_udp_tracker(this);
+  m_vec_idx = manager->connection_manager()->get_udp_tracker_count() - 1;
+  m_resolver_callback = std::bind(&ConnectionManager::start_udp_announce, manager->connection_manager(), m_vec_idx, std::placeholders::_1, std::placeholders::_2);
 #else
   m_resolver_callback = std::bind(&TrackerUdp::start_announce, this, std::placeholders::_1, std::placeholders::_2);
 #endif
@@ -86,6 +88,9 @@ TrackerUdp::TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int fla
 }
 
 TrackerUdp::~TrackerUdp() {
+#ifdef USE_UDNS
+  manager->connection_manager()->null_udp_tracker(m_vec_idx);
+#endif
   close_directly();
 }
   

--- a/libtorrent/src/tracker/tracker_udp.h
+++ b/libtorrent/src/tracker/tracker_udp.h
@@ -105,6 +105,10 @@ private:
   uint32_t            m_action;
   uint64_t            m_connectionId;
   uint32_t            m_transactionId;
+  
+#ifdef USE_UDNS
+  uint64_t            m_vec_idx;
+#endif  
 
   ReadBuffer*         m_readBuffer;
   WriteBuffer*        m_writeBuffer;

--- a/libtorrent/src/tracker/tracker_udp.h
+++ b/libtorrent/src/tracker/tracker_udp.h
@@ -75,14 +75,14 @@ public:
   virtual void        event_read();
   virtual void        event_write();
   virtual void        event_error();
+  
+  void                start_announce(const sockaddr* sa, int err);
 
 private:
   void                close_directly();
 
   void                receive_failed(const std::string& msg);
   void                receive_timeout();
-
-  void                start_announce(const sockaddr* sa, int err);
 
   void                prepare_connect_input();
   void                prepare_announce_input();


### PR DESCRIPTION
We can't send UDP tracker object references through `std::bind()` because it copies them, resulting in memory address errors. So we need to store them higher up in the connection manager, where they are always valid.