### PR TITLE
libtorrent: Optimize UDP trackers for UDNS

### DIFF
--- a/libtorrent/src/net/socket_datagram.cc
+++ b/libtorrent/src/net/socket_datagram.cc
@@ -53,10 +53,9 @@ SocketDatagram::read_datagram(void* buffer, unsigned int length, rak::socket_add
     throw internal_error("Tried to receive buffer length 0");
 
   int r;
-  socklen_t fromlen;
 
   if (sa != NULL) {
-    fromlen = sizeof(rak::socket_address);
+    socklen_t fromlen = sizeof(rak::socket_address);
     r = ::recvfrom(m_fileDesc, buffer, length, 0, sa->c_sockaddr(), &fromlen);
   } else {
     r = ::recv(m_fileDesc, buffer, length, 0);
@@ -85,5 +84,16 @@ SocketDatagram::write_datagram(const void* buffer, unsigned int length, rak::soc
 
   return r;
 }
+
+#ifdef USE_UDNS
+int
+SocketDatagram::write_datagram_ipv4(const void* buffer, unsigned int length, rak::socket_address* sa) {
+  if (length == 0)
+    throw internal_error("Tried to send buffer length 0");
+
+  return sa != NULL ? ::sendto(m_fileDesc, buffer, length, 0, sa->c_sockaddr(), sa->length())
+                    : ::send(m_fileDesc, buffer, length, 0);
+}
+#endif
 
 }

--- a/libtorrent/src/net/socket_datagram.h
+++ b/libtorrent/src/net/socket_datagram.h
@@ -48,6 +48,9 @@ public:
   // used.
   int                 read_datagram(void* buffer, unsigned int length, rak::socket_address* sa = NULL);
   int                 write_datagram(const void* buffer, unsigned int length, rak::socket_address* sa = NULL);
+#ifdef USE_UDNS
+  int                 write_datagram_ipv4(const void* buffer, unsigned int length, rak::socket_address* sa = NULL);
+#endif
 };
 
 }

--- a/libtorrent/src/net/socket_fd.cc
+++ b/libtorrent/src/net/socket_fd.cc
@@ -162,6 +162,14 @@ SocketFd::open_datagram() {
   return true;
 }
 
+#ifdef USE_UDNS
+bool
+SocketFd::open_datagram_ipv4() {
+  m_ipv6_socket = false;
+  return (m_fd = socket(rak::socket_address::pf_inet, SOCK_DGRAM, 0)) != -1;
+}
+#endif
+
 bool
 SocketFd::open_local() {
   return (m_fd = socket(rak::socket_address::pf_local, SOCK_STREAM, 0)) != -1;
@@ -197,6 +205,15 @@ SocketFd::bind(const rak::socket_address& sa) {
 
   return !::bind(m_fd, sa.c_sockaddr(), sa.length());
 }
+
+#ifdef USE_UDNS
+bool
+SocketFd::bind_ipv4(const rak::socket_address& sa) {
+  check_valid();
+
+  return !::bind(m_fd, sa.c_sockaddr(), sa.length());
+}
+#endif
 
 bool
 SocketFd::bind(const rak::socket_address& sa, unsigned int length) {

--- a/libtorrent/src/net/socket_fd.h
+++ b/libtorrent/src/net/socket_fd.h
@@ -72,6 +72,10 @@ public:
   bool                open_stream();
   bool                open_datagram();
   bool                open_local();
+  
+#ifdef USE_UDNS
+  bool                open_datagram_ipv4();
+#endif
 
   static bool         open_socket_pair(int& fd1, int& fd2);
 
@@ -82,6 +86,10 @@ public:
   bool                bind(const rak::socket_address& sa, unsigned int length);
   bool                connect(const rak::socket_address& sa);
   bool                getsockname(rak::socket_address* sa);
+  
+#ifdef USE_UDNS
+  bool                bind_ipv4(const rak::socket_address& sa);
+#endif
 
   bool                listen(int size);
   SocketFd            accept(rak::socket_address* sa);


### PR DESCRIPTION
This commit optimizes UDP trackers with a fast path to ipv4 sockets. When using UDNS, we know the address is going to resolve to IPV4. We can skip a few checks to increase performance.