### PR TITLE
libtorrent: Fix compile warning with udp_tracker_info

### DIFF
--- a/libtorrent/rak/udp_tracker_info.h
+++ b/libtorrent/rak/udp_tracker_info.h
@@ -52,7 +52,7 @@ private:
     int port;
     udp_tracker_info new_info;
 
-    if (sscanf(url.c_str(), "udp://%1023[^:]:%i/announce", &hostname, &port) == 2 && hostname[0] != '\0' && port > 0 && port < (1 << 16)) {
+    if (sscanf(url.c_str(), "udp://%1023[^:]:%i/announce", hostname, &port) == 2 && hostname[0] != '\0' && port > 0 && port < (1 << 16)) {
       new_info.set(url, hostname, port);
       base_type::push_back(new_info);
       return new_info;


### PR DESCRIPTION
```
../../rak/udp_tracker_info.h: In member function 'rak::udp_tracker_info rak::udp_tracker_vector::create_info(std::string)':
../../rak/udp_tracker_info.h:55:43: warning: format '%[^:' expects argument of type 'char*', but argument 3 has type 'char (*)[1024]' [-Wformat=]
   55 |     if (sscanf(url.c_str(), "udp://%1023[^:]:%i/announce", &hostname, &port) == 2 && hostname[0] != '\0' && port > 0 && port < (1 << 16)) {
      |                                    ~~~~~~~^                ~~~~~~~~~
      |                                           |                |
      |                                           char*            char (*)[1024]
```