### PR TITLE
libtorrent: Use std::shuffle

### DIFF
--- a/libtorrent/src/torrent/tracker_list.cc
+++ b/libtorrent/src/torrent/tracker_list.cc
@@ -37,6 +37,7 @@
 #include "config.h"
 
 #include <functional>
+#include <random>
 
 #include "net/address_list.h"
 #include "torrent/utils/log.h"
@@ -300,12 +301,14 @@ TrackerList::promote(iterator itr) {
 
 void
 TrackerList::randomize_group_entries() {
+  static std::random_device rd;
+  static std::mt19937       rng(rd());
   // Random random random.
   iterator itr = begin();
   
   while (itr != end()) {
     iterator tmp = end_group((*itr)->group());
-    std::random_shuffle(itr, tmp);
+    std::shuffle(itr, tmp, rng);
 
     itr = tmp;
   }


### PR DESCRIPTION
`std::random_shuffle` is removed in C++17.

Reference: https://github.com/rakshasa/libtorrent/commit/28b61e09569db5782e3d2e9c89bdd1bef05d38ed